### PR TITLE
Mystery poo

### DIFF
--- a/SchoolPrototype.gmx/sprites/spr_dwarf_walk_e.sprite.gmx
+++ b/SchoolPrototype.gmx/sprites/spr_dwarf_walk_e.sprite.gmx
@@ -8,7 +8,7 @@
   <sepmasks>0</sepmasks>
   <bboxmode>2</bboxmode>
   <bbox_left>10</bbox_left>
-  <bbox_right>20</bbox_right>
+  <bbox_right>21</bbox_right>
   <bbox_top>20</bbox_top>
   <bbox_bottom>31</bbox_bottom>
   <HTile>0</HTile>

--- a/SchoolPrototype.gmx/sprites/spr_dwarf_walk_n.sprite.gmx
+++ b/SchoolPrototype.gmx/sprites/spr_dwarf_walk_n.sprite.gmx
@@ -8,7 +8,7 @@
   <sepmasks>0</sepmasks>
   <bboxmode>2</bboxmode>
   <bbox_left>10</bbox_left>
-  <bbox_right>20</bbox_right>
+  <bbox_right>21</bbox_right>
   <bbox_top>20</bbox_top>
   <bbox_bottom>31</bbox_bottom>
   <HTile>0</HTile>

--- a/SchoolPrototype.gmx/sprites/spr_dwarf_walk_s.sprite.gmx
+++ b/SchoolPrototype.gmx/sprites/spr_dwarf_walk_s.sprite.gmx
@@ -8,7 +8,7 @@
   <sepmasks>0</sepmasks>
   <bboxmode>2</bboxmode>
   <bbox_left>10</bbox_left>
-  <bbox_right>20</bbox_right>
+  <bbox_right>21</bbox_right>
   <bbox_top>20</bbox_top>
   <bbox_bottom>31</bbox_bottom>
   <HTile>0</HTile>


### PR DESCRIPTION
Bug Fix: Dwarf sprites collision box
- The collision box was asymmetric. One pixel too narrow. Fixed.
