### PR TITLE
Network Optimization

### DIFF
--- a/SchoolPrototype.gmx/objects/obj_Client.object.gmx
+++ b/SchoolPrototype.gmx/objects/obj_Client.object.gmx
@@ -28,8 +28,8 @@
             <string>/// Connection
 var Type, IPAddress, Port;
 Type = network_socket_tcp;
-IPAddress = "184.91.74.235";
-//IPAddress = "127.0.0.1";
+//IPAddress = "184.91.74.235";
+IPAddress = "127.0.0.1";
 Port = 6969;
 Socket = network_create_socket( Type );
 isConnected = network_connect( Socket , IPAddress , Port );
@@ -126,6 +126,28 @@ StatusQueue = ds_queue_create();
         <arguments>
           <argument>
             <kind>1</kind>
+            <string>/// Attack Queue
+AttackQueue = ds_queue_create();
+</string>
+          </argument>
+        </arguments>
+      </action>
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
             <string>/// Ready
 Ready = false;
 </string>
@@ -152,6 +174,28 @@ Ready = false;
 Ping = 999;
 PingTimer = 30;
 LastPing = current_time;
+</string>
+          </argument>
+        </arguments>
+      </action>
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>/// Get Player Name
+PlayerNameMsg = get_string_async( "Name", "Unnamed" );
 </string>
           </argument>
         </arguments>
@@ -185,7 +229,18 @@ for( var s = 0; s &lt; ds_list_size( SocketList ); ++s )
     ds_map_destroy( _lMap );
 }
 ds_list_destroy( SocketList );
+while( !ds_queue_empty( StatusQueue ) )
+{
+    var _sMap = ds_queue_dequeue( StatusQueue );
+    ds_map_destroy( _sMap );
+}
 ds_queue_destroy( StatusQueue );
+while( !ds_queue_empty( AttackQueue ) )
+{
+    var _aMap = ds_queue_dequeue( AttackQueue );
+    ds_map_destroy( _aMap );
+}
+ds_queue_destroy( AttackQueue );
 </string>
           </argument>
         </arguments>
@@ -356,7 +411,7 @@ for( var s = 0; s &lt; ds_list_size( SocketList ); ++s )
         // Request the player's name
         buffer_seek( Buffer, buffer_seek_start, 0 );
         buffer_write( Buffer, buffer_u8, 3 );
-        //network_send_packet( Socket, Buffer, buffer_tell( Buffer ) );
+        network_send_packet( Socket, Buffer, buffer_tell( Buffer ) );
     }
     // Update Position of instance
     with( _inst )
@@ -379,20 +434,6 @@ for( var s = 0; s &lt; ds_list_size( SocketList ); ++s )
             }
             else
                 MaxSpeed = _speed;
-        }
-    }
-    // Create an attack if applicable
-    var _aMap = _lMap[? "AttackMap" ];
-    if( _aMap[? "Object" ] != "noone" )
-    {
-        var _Object = asset_get_index( _aMap[? "Object" ] );
-        if( _Object != -1 &amp;&amp; _lMap[? "Socket" ] != NetworkID )
-        {
-            var _attack = instance_create( _aMap[? "X" ], _aMap[? "Y" ], _Object );
-            _attack.Owner = _inst;
-            _attack.direction = _aMap[? "Direction" ];
-            _attack.image_angle = _attack.direction;
-            _aMap[? "Object" ] = "noone";
         }
     }
 }
@@ -440,6 +481,53 @@ while( !ds_queue_empty( StatusQueue ) )
           </argument>
         </arguments>
       </action>
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>/// Attack Queue
+while( !ds_queue_empty( AttackQueue ) )
+{
+    var _aMap = ds_queue_dequeue( AttackQueue );
+    if( _aMap[? "Socket" ] != NetworkID )
+    {
+        var _Object = asset_get_index( _aMap[? "Object" ] );
+        if( _Object != -1 )
+        {
+            var _inst = noone;
+            for( var s = 0; s &lt; ds_list_size( SocketList ); ++s )
+            {
+                var _lMap = SocketList[| s ];
+                if( _lMap[? "Socket" ] == _aMap[? "Socket" ] )
+                    _inst = _lMap[? "Instance" ];
+            }
+            if( _inst != noone )
+            {
+                var _attack = instance_create( _aMap[? "X" ], _aMap[? "Y" ], _Object );
+                _attack.Owner = _inst;
+                _attack.direction = _aMap[? "Direction" ];
+                _attack.image_angle = _attack.direction;
+            }
+        }
+    }
+    ds_map_destroy( _aMap );
+}
+</string>
+          </argument>
+        </arguments>
+      </action>
     </event>
     <event eventtype="7" enumb="68">
       <action>
@@ -467,6 +555,44 @@ switch( type_event )
         buffer_seek( buffer , buffer_seek_start , 0 );
         scr_CReceivedPacket( buffer );
         break;
+}
+</string>
+          </argument>
+        </arguments>
+      </action>
+    </event>
+    <event eventtype="7" enumb="63">
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>/// Process name
+var _id = ds_map_find_value( async_load, "id" );
+if( _id == PlayerNameMsg )
+{
+    if( ds_map_find_value( async_load, "status" ) )
+    {
+        if( ds_map_find_value( async_load, "result" ) != "" )
+        {
+            var _name = ds_map_find_value( async_load, "result" );
+            buffer_seek( Buffer, buffer_seek_start, 0 );
+            buffer_write( Buffer, buffer_u8, 4 );
+            buffer_write( Buffer, buffer_string, _name );
+            network_send_packet( Socket, Buffer, buffer_tell( Buffer ) );
+        }
+    }
 }
 </string>
           </argument>
@@ -509,6 +635,7 @@ for( var s = 0; s &lt; ds_list_size( SocketList ); ++s )
         else
             draw_set_colour( c_red );
         draw_rectangle( _inst.x, _inst.y, _inst.x + 16, _inst.y + 16, false );
+        draw_text( _inst.x, _inst.y + 32, _lMap[? "Name" ] );
     }
 }
 </string>
@@ -540,6 +667,30 @@ buffer_seek( Buffer, buffer_seek_start, 0 );
 buffer_write( Buffer, buffer_u8, 6 );
 buffer_write( Buffer, buffer_u8, Ready );
 network_send_packet( Socket, Buffer, buffer_tell( Buffer ) );
+</string>
+          </argument>
+        </arguments>
+      </action>
+    </event>
+    <event eventtype="9" enumb="27">
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>network_destroy( Socket );
+instance_destroy();
 </string>
           </argument>
         </arguments>

--- a/SchoolPrototype.gmx/objects/obj_Dwarf.object.gmx
+++ b/SchoolPrototype.gmx/objects/obj_Dwarf.object.gmx
@@ -329,10 +329,9 @@ if( State != "Death" )
                 buffer_seek( obj_Client.Buffer, buffer_seek_start, 0 );
                 buffer_write( obj_Client.Buffer, buffer_u8, 5 );
                 buffer_write( obj_Client.Buffer, buffer_string, object_get_name( inst.object_index ) );
-                buffer_write( obj_Client.Buffer, buffer_s16, x );
-                buffer_write( obj_Client.Buffer, buffer_s16, y - 16 );
+                buffer_write( obj_Client.Buffer, buffer_u16, x );
+                buffer_write( obj_Client.Buffer, buffer_u16, y - 16 );
                 buffer_write( obj_Client.Buffer, buffer_s16, obj_Gesture1.direction );
-                buffer_write( obj_Client.Buffer, buffer_s8, global.MyWeapon.speed );
                 network_send_packet( obj_Client.Socket, obj_Client.Buffer, buffer_tell( obj_Client.Buffer ) );
                 //with( inst )
                     //instance_destroy();

--- a/SchoolPrototype.gmx/objects/obj_Server.object.gmx
+++ b/SchoolPrototype.gmx/objects/obj_Server.object.gmx
@@ -100,6 +100,28 @@ StatusQueue = ds_queue_create();
         <arguments>
           <argument>
             <kind>1</kind>
+            <string>/// Attack Queue
+AttackQueue = ds_queue_create();
+</string>
+          </argument>
+        </arguments>
+      </action>
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
             <string>/// Update Timer
 UpdateTimer = 0;
 </string>
@@ -164,7 +186,18 @@ for( var s = 0; s &lt; ds_list_size( SocketList ); ++s )
     ds_map_destroy( _lMap );
 }
 ds_list_destroy( SocketList );
+while( !ds_queue_empty( StatusQueue ) )
+{
+    var _sMap = ds_queue_dequeue( StatusQueue );
+    ds_map_destroy( _sMap );
+}
 ds_queue_destroy( StatusQueue );
+while( !ds_queue_empty( AttackQueue ) )
+{
+    var _aMap = ds_queue_dequeue( AttackQueue );
+    ds_map_destroy( _aMap );
+}
+ds_queue_destroy( AttackQueue );
 </string>
           </argument>
         </arguments>
@@ -254,20 +287,6 @@ if( UpdateTimer == 0 )
                     MaxSpeed = _speed;
             }
         }
-        // Create an attack if necessary
-        var _aMap = _lMap[? "AttackMap" ];
-        if( _aMap[? "Object" ] != "noone" )
-        {
-            var _Object = asset_get_index( _aMap[? "Object" ] );
-            if( _Object != -1 )
-            {
-                var _attack = instance_create( _aMap[? "X" ], _aMap[? "Y" ], _Object );
-                _attack.Owner = _dwarf;
-                _attack.direction = _aMap[? "Direction" ];
-                _attack.image_angle = _attack.direction;
-                _attack.speed = _aMap[? "Speed" ];
-            }
-        }
     }
     // Create ready state snapshot packet
     buffer_seek( Buffer, buffer_seek_start, 0 );
@@ -303,27 +322,6 @@ if( UpdateTimer == 0 )
         var _lMap = SocketList[| s ];
         network_send_packet( _lMap[? "Socket" ] , Buffer, buffer_tell( Buffer ) );
     }
-    // Create attack snapshot packet
-    buffer_seek( Buffer, buffer_seek_start, 0 );
-    buffer_write( Buffer, buffer_u8, 5 );
-    buffer_write( Buffer, buffer_u8, ListSize );
-    for( var s = 0; s &lt; ListSize; ++s )
-    {
-        var _lMap = SocketList[| s ];
-        var _aMap = _lMap[? "AttackMap" ];
-        buffer_write( Buffer, buffer_u8, _lMap[? "Socket" ] );
-        buffer_write( Buffer, buffer_string, _aMap[? "Object" ] );
-        buffer_write( Buffer, buffer_s16, _aMap[? "X" ] );
-        buffer_write( Buffer, buffer_s16, _aMap[? "Y" ] );
-        buffer_write( Buffer, buffer_s16, _aMap[? "Direction" ] );
-        buffer_write( Buffer, buffer_u8, _aMap[? "Speed" ] );
-        _aMap[? "Object" ] = "noone";
-    }
-    for( var s = 0; s &lt; ListSize; ++s )
-    {
-        var _lMap = SocketList[| s ];
-        network_send_packet( _lMap[? "Socket" ], Buffer, buffer_tell( Buffer ) );
-    }
     // Create Status snapshot
     if( !ds_queue_empty( StatusQueue ) )
     {
@@ -343,7 +341,46 @@ if( UpdateTimer == 0 )
             network_send_packet( _lMap[? "Socket" ], Buffer, buffer_tell( Buffer ) );
         }
     }
-    
+    // Create Attack snapshot
+    if( !ds_queue_empty( AttackQueue ) )
+    {
+        buffer_seek( Buffer, buffer_seek_start, 0 );
+        buffer_write( Buffer, buffer_u8, 5 );
+        buffer_write( Buffer, buffer_u8, ds_queue_size( AttackQueue ) );
+        while( !ds_queue_empty( AttackQueue ) )
+        {
+            var _aMap = ds_queue_dequeue( AttackQueue );
+            buffer_write( Buffer, buffer_u8, _aMap[? "Socket" ] );
+            buffer_write( Buffer, buffer_string, _aMap[? "Object" ] );
+            buffer_write( Buffer, buffer_u16, _aMap[? "X" ] );
+            buffer_write( Buffer, buffer_u16, _aMap[? "Y" ] );
+            buffer_write( Buffer, buffer_s16, _aMap[? "Direction" ] );
+            var _Object = asset_get_index( _aMap[? "Object" ] );
+            if( _Object != -1 )
+            {
+                var _inst = noone;
+                for( var s = 0; s &lt; ds_list_size( SocketList ); ++s )
+                {
+                    var _lMap = SocketList[| s ];
+                    if( _lMap[? "Socket" ] == _aMap[? "Socket" ] )
+                        _inst = _lMap[? "Instance" ];
+                }
+                if( _inst != noone )
+                {
+                    var _attack = instance_create( _aMap[? "X" ], _aMap[? "Y" ], _Object );
+                    _attack.Owner = _inst;
+                    _attack.direction = _aMap[? "Direction" ];
+                    _attack.image_angle = _attack.direction;
+                }
+            }
+            ds_map_destroy( _aMap );
+        }
+        for( var s = 0; s &lt; ListSize; ++s )
+        {
+            var _lMap = SocketList[| s ];
+            network_send_packet( _lMap[? "Socket" ], Buffer, buffer_tell( Buffer ) );
+        }
+    }
 }
 </string>
           </argument>

--- a/SchoolPrototype.gmx/scripts/scr_CReceivedPacket.gml
+++ b/SchoolPrototype.gmx/scripts/scr_CReceivedPacket.gml
@@ -96,23 +96,16 @@ switch( msgid ) {
         {
             var _socket = buffer_read( buffer, buffer_u8 );
             var _Object = buffer_read( buffer, buffer_string );
-            var _x = buffer_read( buffer, buffer_s16 );
-            var _y = buffer_read( buffer, buffer_s16 );
+            var _x = buffer_read( buffer, buffer_u16 );
+            var _y = buffer_read( buffer, buffer_u16 );
             var _dir = buffer_read( buffer, buffer_s16 );
-            var _speed = buffer_read( buffer, buffer_s8 );
-            for( var s = 0; s < ds_list_size( SocketList ); ++s )
-            {
-                var _lMap = SocketList[| s ];
-                if( _lMap[? "Socket" ] == _socket )
-                {
-                    var _aMap = _lMap[? "AttackMap" ];
-                    _aMap[? "Object" ] = _Object;
-                    _aMap[? "X" ] = _x;
-                    _aMap[? "Y" ] = _y;
-                    _aMap[? "Direction" ] = _dir;
-                    _aMap[? "Speed" ] = _speed;
-                }
-            }
+            var _aMap = ds_map_create();
+            _aMap[? "Socket" ] = _socket;
+            _aMap[? "Object" ] = _Object;
+            _aMap[? "X" ] = _x;
+            _aMap[? "Y" ] = _y;
+            _aMap[? "Direction" ] = _dir;
+            ds_queue_enqueue( AttackQueue, _aMap );
         }
         break;
     case 6:     // Update Ready status

--- a/SchoolPrototype.gmx/scripts/scr_SReceivedPacket.gml
+++ b/SchoolPrototype.gmx/scripts/scr_SReceivedPacket.gml
@@ -20,10 +20,13 @@ switch( msgid ) {
             if( _lMap[? "Socket" ] == socket )
             {
                 var _pMap = _lMap[? "PositionMap" ];
-                _pMap[? "X" ]           = _x;
-                _pMap[? "Y" ]           = _y;
-                _pMap[? "Direction" ]   = _dir;
-                _pMap[? "Speed" ]       = _speed;
+                if( point_distance( _pMap[? "X" ], _pMap[? "Y" ], _x, _y ) < 32 )
+                {
+                    _pMap[? "X" ]           = _x;
+                    _pMap[? "Y" ]           = _y;
+                    _pMap[? "Direction" ]   = _dir;
+                    _pMap[? "Speed" ]       = _speed;
+                }
             }
         }
         break;
@@ -39,28 +42,35 @@ switch( msgid ) {
         }
         network_send_packet( socket, Buffer, buffer_tell( Buffer ) );
         break;
-    case 4: // Client disconnected -- DEPRECATED
-        
-        break;
-    case 5: // Client made an attack
-        var _Object = buffer_read( buffer, buffer_string );
-        var _x = buffer_read( buffer, buffer_s16 );
-        var _y = buffer_read( buffer, buffer_s16 );
-        var _dir = buffer_read( buffer, buffer_s16 );
-        var _speed = buffer_read( buffer, buffer_u8 );
+    case 4: // Set Name
+        var _name = buffer_read( buffer, buffer_string );
         for( var s = 0; s < ds_list_size( SocketList ); ++s )
         {
             var _lMap = SocketList[| s ];
             if( _lMap[? "Socket" ] == socket )
             {
-                var _aMap = _lMap[? "AttackMap" ];
-                _aMap[? "Object" ] = _Object;
-                _aMap[? "X" ] = _x;
-                _aMap[? "Y" ] = _y;
-                _aMap[? "Direction" ] = _dir;
-                _aMap[? "Speed" ] = _speed;
+                _lMap[? "Name" ] = _name;
+                buffer_seek( Buffer, buffer_seek_start, 0 );
+                buffer_write( Buffer, buffer_u8, 7 );
+                buffer_write( Buffer, buffer_u8, 1 );
+                buffer_write( Buffer, buffer_u8, socket );
+                buffer_write( Buffer, buffer_string, _name );
+                network_send_packet( socket, Buffer, buffer_tell( Buffer ) );
             }
         }
+        break;
+    case 5: // Client made an attack
+        var _Object = buffer_read( buffer, buffer_string );
+        var _x = buffer_read( buffer, buffer_u16 );
+        var _y = buffer_read( buffer, buffer_u16 );
+        var _dir = buffer_read( buffer, buffer_s16 );
+        var _aMap = ds_map_create();
+        _aMap[? "Socket" ] = socket;
+        _aMap[? "Object" ] = _Object;
+        _aMap[? "X" ] = _x;
+        _aMap[? "Y" ] = _y;
+        _aMap[? "Direction" ] = _dir;
+        ds_queue_enqueue( AttackQueue, _aMap );
         break;
     case 6: // Client is "ready"
         var _ready = buffer_read( buffer, buffer_u8 );


### PR DESCRIPTION
The old way that attacks were processed was to send a current snapshot of everyone's attacks which meant a couple of things. Firstly, you could only attack once every 100ms based on the network setup. Secondly, even if no one was attacking the same bandwidth was used to send "empty" snapshots ( a snapshot saying, this player is NOT attacking ). Very stupid... Although, bandwidth usage was constant and predictable. Useless.

The new way copies the way of Status updates ( the thing that tells people when they die for now ). Essentially it's a queue of changes that is sent as a snapshot so it's variant in size every tick, which means, that for the majority of ticks it will be zero ( because we're way slower to attack than once or more per 100ms ). So bandwidth usage increases linearly with number of concurrent attacks. This technically should be a maximum usage of the previous setup, so our average bandwidth has been reduced significantly.

Also, a few packet optimizations were made to decrease usage, too. More to come!
